### PR TITLE
Text editor event changed

### DIFF
--- a/skottie/modules/skottie-sk/skottie-sk.js
+++ b/skottie/modules/skottie-sk/skottie-sk.js
@@ -324,8 +324,28 @@ define('skottie-sk', class extends HTMLElement {
   }
 
   _applyTextEdits(event) {
-    const animation = event.detail;
-    this._state.lottie = animation;
+    const texts = event.detail.texts;
+    const currentAnimation = JSON.parse(JSON.stringify(this._state.lottie));
+    texts.forEach((textData) => {
+      textData.items.forEach((item) => {
+        let layers;
+        // Searches for composition that contains this layer
+        if (!item.parentId) {
+          layers = currentAnimation.layers;
+        } else {
+          const asset = currentAnimation.assets.find((assetItem) => assetItem.id === item.parentId);
+          layers = asset ? asset.layers : [];
+        }
+
+        // Replaces current animation layer with new layer value
+        layers.forEach((layer, index) => {
+          if (layer.ind === item.layer.ind) {
+            layers[index] = item.layer;
+          }
+        });
+      });
+    });
+    this._state.lottie = currentAnimation;
     this._upload();
   }
 

--- a/skottie/modules/skottie-sk/skottie-sk.js
+++ b/skottie/modules/skottie-sk/skottie-sk.js
@@ -329,7 +329,7 @@ define('skottie-sk', class extends HTMLElement {
     texts.forEach((textData) => {
       textData.items.forEach((item) => {
         let layers;
-        // Searches for composition that contains this layer
+        // Searches for a composition that contains this layer
         if (!item.parentId) {
           layers = currentAnimation.layers;
         } else {
@@ -339,7 +339,9 @@ define('skottie-sk', class extends HTMLElement {
 
         // Replaces current animation layer with new layer value
         layers.forEach((layer, index) => {
-          if (layer.ind === item.layer.ind) {
+          if (layer.ind === item.layer.ind
+            && layer.nm === item.layer.nm
+          ) {
             layers[index] = item.layer;
           }
         });

--- a/skottie/modules/skottie-text-editor/skottie-text-editor.js
+++ b/skottie/modules/skottie-text-editor/skottie-text-editor.js
@@ -157,7 +157,9 @@ class SkottieTextEditorSk extends HTMLElement {
 
   _save() {
     this.dispatchEvent(new CustomEvent('apply', {
-      detail: this._animation,
+      detail: {
+        texts: this._state.texts,
+      },
     }));
   }
 


### PR DESCRIPTION
I'm changing the event dispatched by the text editor, so it can be used in a future PR to modify multiple animations at once.
In order to do that, on this PR, the text editor dispatches the text data and the `skottie-sk` component takes care of updating the animation with the new values.